### PR TITLE
Updates to /leaderboard command

### DIFF
--- a/pzsd_bot/cogs/points.py
+++ b/pzsd_bot/cogs/points.py
@@ -1,12 +1,14 @@
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import Optional
 
 import discord
-from discord import ApplicationContext, Bot, Message, default_permissions
-from discord.commands import option
+from discord import ApplicationContext, Bot, Embed, Message, default_permissions
+from discord.commands import SlashCommandGroup, option
 from discord.ext.commands import Cog, slash_command
 from sqlalchemy import insert, select, text, update
+from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.functions import sum as sql_sum
 
 from pzsd_bot.db import Session
@@ -28,6 +30,8 @@ logger = logging.getLogger(__name__)
 
 
 class Points(Cog):
+    leaderboard = SlashCommandGroup("leaderboard", "Display point leaderboards.")
+
     def __init__(self, bot: Bot):
         self.bot = bot
 
@@ -181,8 +185,9 @@ class Points(Cog):
         points_log_channel = self.bot.get_channel(Channels.points_log)
         await points_log_channel.send(embed=embed)
 
-    @slash_command(description="Display everyone's points in descending order.")
-    async def leaderboard(self, ctx: ApplicationContext) -> None:
+    async def fetch_leaderboard(
+        self, *args: list[BinaryExpression]
+    ) -> list[tuple[str, int]]:
         async with Session.begin() as session:
             j = ledger.join(
                 pzsd_user, pzsd_user.c.id == ledger.c.recipient, isouter=True
@@ -191,17 +196,48 @@ class Points(Cog):
                 select(pzsd_user.c.name, sql_sum(ledger.c.points))
                 .select_from(j)
                 .where(pzsd_user.c.is_active == True)
+                .where(*args)
                 .group_by(pzsd_user.c.id)
             )
-            points = sorted(result.fetchall(), key=lambda r: r.sum, reverse=True)
+            leaderboard = sorted(result.fetchall(), key=lambda r: r.sum, reverse=True)
 
-        embed = discord.Embed(title="Points Leaderboard", colour=Colors.yellowy.value)
-        for i, (name, point_total) in enumerate(points, 1):
-            name = name.capitalize()
+        return leaderboard
+
+    def make_leaderboard_embed(
+        self,
+        title: str,
+        leaderboard: list[tuple[str, int]],
+        description: Optional[str] = None,
+    ) -> Embed:
+        embed = Embed(title=title, description=description, colour=Colors.yellowy.value)
+        for i, (name, point_total) in enumerate(leaderboard, 1):
+            # title case name by only capitalizing
+            # words separated by hyphen or space
+            name = "".join(map(str.capitalize, re.split(r"( |-)", name)))
             point_total = int(point_total)  # avoid scientific notation
             embed.add_field(
                 name=f"{i}. {name}", value=f"{point_total:,} points", inline=False
             )
+
+        return embed
+
+    @leaderboard.command(description="Display points awarded in the last 7 days.")
+    async def weekly(self, ctx: ApplicationContext) -> None:
+        last_week = datetime.now() - timedelta(days=7)
+        leaderboard = await self.fetch_leaderboard(ledger.c.created_at > last_week)
+        description = "Points awarded after " + last_week.strftime("%a %b %-d %-I:%M%p")
+        embed = self.make_leaderboard_embed(
+            "Weekly Points Leaderboard", leaderboard, description=description
+        )
+
+        await ctx.respond(embed=embed)
+
+    @leaderboard.command(
+        description="Display total points awarded from the beginning of time."
+    )
+    async def total(self, ctx: ApplicationContext) -> None:
+        leaderboard = await self.fetch_leaderboard()
+        embed = self.make_leaderboard_embed("All Time Points Leaderboard", leaderboard)
 
         await ctx.respond(embed=embed)
 

--- a/pzsd_bot/cogs/points.py
+++ b/pzsd_bot/cogs/points.py
@@ -41,11 +41,15 @@ class Points(Cog):
             if recipient_name is not None:
                 recipient_name = recipient_name.strip('"')
             recipient_id = match["recipient_id"]
-        elif message.reference and (match := REPLY_POINT_PATTERN.fullmatch(message.content)):
+        elif message.reference and (
+            match := REPLY_POINT_PATTERN.fullmatch(message.content)
+        ):
             original_message = self.bot.get_message(message.reference.message_id)
             # message wasn't cached, make api call
             if original_message is None:
-                original_message = await message.channel.fetch_message(message.reference.message_id)
+                original_message = await message.channel.fetch_message(
+                    message.reference.message_id
+                )
             recipient_name = None
             recipient_id = str(original_message.author.id)
         else:
@@ -82,9 +86,7 @@ class Points(Cog):
 
             if not is_to_everyone:
                 result = await session.execute(
-                    select(pzsd_user).where(
-                        condition & pzsd_user.c.is_active == True
-                    )
+                    select(pzsd_user).where(condition & pzsd_user.c.is_active == True)
                 )
 
                 recipient = result.one_or_none()
@@ -109,9 +111,7 @@ class Points(Cog):
             )
             return
 
-        self_point_violation = (
-            is_to_everyone is False and bestower.id == recipient.id
-        )
+        self_point_violation = is_to_everyone is False and bestower.id == recipient.id
         if not self_point_violation:
             logger.info(
                 "%s awarding %s point(s) to %s",
@@ -176,9 +176,7 @@ class Points(Cog):
         message_content = message.content
         if len(message_content) > 80:
             message_content = message_content[:80] + "\N{HORIZONTAL ELLIPSIS}"
-        embed.add_field(
-            name="Content of message:", value=message_content, inline=False
-        )
+        embed.add_field(name="Content of message:", value=message_content, inline=False)
 
         points_log_channel = self.bot.get_channel(Channels.points_log)
         await points_log_channel.send(embed=embed)

--- a/pzsd_bot/cogs/points.py
+++ b/pzsd_bot/cogs/points.py
@@ -210,13 +210,13 @@ class Points(Cog):
         description: Optional[str] = None,
     ) -> Embed:
         embed = Embed(title=title, description=description, colour=Colors.yellowy.value)
-        for i, (name, point_total) in enumerate(leaderboard, 1):
+        for rank, (name, point_total) in enumerate(leaderboard, 1):
             # title case name by only capitalizing
             # words separated by hyphen or space
             name = "".join(map(str.capitalize, re.split(r"( |-)", name)))
             point_total = int(point_total)  # avoid scientific notation
             embed.add_field(
-                name=f"{i}. {name}", value=f"{point_total:,} points", inline=False
+                name=f"{rank}. {name}", value=f"{point_total:,} points", inline=False
             )
 
         return embed


### PR DESCRIPTION
Make `/leaderboard` a command group and add `total` and `weekly` sub commands. `/leaderboard total` behaves how `/leaderboard` used to aside from better name capitalization, and `/leaderboard weekly` only displays names that have been bestowed points in the last 7 days.