### PR TITLE
Fix bug in /register command

### DIFF
--- a/pzsd_bot/cogs/points.py
+++ b/pzsd_bot/cogs/points.py
@@ -246,7 +246,7 @@ class Points(Cog):
     @option("snowflake", description="Their discord ID if applicable.", required=False)
     @default_permissions(administrator=True)
     async def register(
-        self, ctx: ApplicationContext, name: str, snowflake: int
+        self, ctx: ApplicationContext, name: str, snowflake: str
     ) -> None:
         name = name.lower().strip()
 


### PR DESCRIPTION
Some idiot made the type for the snowflake arg an `int` instead of a `str`. Discord snowflakes are too big to be ints ya dummy.