### PR TITLE
Fix paginator timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pzsd-bot"
-version = "1.11.0"
+version = "1.11.1"
 description = "Discord bot for the PZSD server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pzsd_bot/cogs/points/admin.py
+++ b/pzsd_bot/cogs/points/admin.py
@@ -168,7 +168,7 @@ class PointUserAdmin(Cog):
 
         paginator = Paginator(
             pages=pages,
-            disable_on_timeout=False,
+            timeout=None,
             author_check=True,
             use_default_buttons=False,
             custom_buttons=PointsSettings.page_buttons,

--- a/pzsd_bot/cogs/points/leaderboard.py
+++ b/pzsd_bot/cogs/points/leaderboard.py
@@ -102,7 +102,7 @@ class PointLeaderboard(Cog):
 
         paginator = Paginator(
             pages=pages,
-            disable_on_timeout=False,
+            timeout=None,
             author_check=False,
             use_default_buttons=False,
             custom_buttons=PointsSettings.page_buttons,
@@ -125,7 +125,7 @@ class PointLeaderboard(Cog):
 
         paginator = Paginator(
             pages=pages,
-            disable_on_timeout=False,
+            timeout=None,
             author_check=False,
             use_default_buttons=False,
             custom_buttons=PointsSettings.page_buttons,


### PR DESCRIPTION
Seems I used the wrong kwarg to disable the paginator from timing out. `disable_on_timeout` only applies to the buttons, which is why the buttons still "worked" after the paginator was no longer active.

Closes #50 